### PR TITLE
Add mirror workflow

### DIFF
--- a/.github/workflows/repo-mirror.yml
+++ b/.github/workflows/repo-mirror.yml
@@ -1,0 +1,27 @@
+name: Ascend Gitee repos mirror periodic job
+
+on:
+  pull_request:
+    paths:
+    - '.github/workflows/**'
+    # Runs at every pull requests submitted in master branch 
+    branches: [ master ]
+  schedule:
+    # Runs at 0,2,4,6...,22th hour every day (every 2 hours)
+    - cron:  '0 */2 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Mirror the gitee/mindspore org repos to github/mindspore-ai.
+      uses: Yikun/hub-mirror-action@v0.08
+      with:
+        src: gitee/ascend
+        dst: github/ascend
+        dst_key: ${{ secrets.SYNC_ASCEND_PRIVATE_KEY }}
+        dst_token:  ${{ secrets.SYNC_ASCEND_TOKEN }}
+        account_type: org
+        clone_style: ssh


### PR DESCRIPTION
This patch adds the repo mirror workflow to mirror the repo from gitee to github.

This action will executed in every every 2 hours.